### PR TITLE
Sort the options in the tun config.

### DIFF
--- a/templates/tun.erb
+++ b/templates/tun.erb
@@ -13,7 +13,7 @@ options = <%= @options %>
 <% if @global_opts.is_a? Hash and @global_opts.keys.size > 0 -%>
 
 ; additional global options
-  <%- @global_opts.each do |option_name,option_value| -%>
+  <%- @global_opts.sort.map do |option_name,option_value| -%>
 <%= option_name %> = <%= option_value %>
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
When creating a tun config with more than one global option using ruby 1.8 ( the default on ubuntu 12.04) it returns the hash in a random order. This means that the config file changes on most puppet runs and the service restarts.
This just sorts the options by name before looping though keeping them consistent.
