### PR TITLE
ability to override cert option in service_opts

### DIFF
--- a/templates/tun.erb
+++ b/templates/tun.erb
@@ -1,5 +1,4 @@
 # This file managed by Puppet
-cert = <%= @cert_real %>
 
 setuid = root
 setgid = root
@@ -39,6 +38,9 @@ options = <%= @options %>
 <% end -%>
 TIMEOUTidle = <%= @timeoutidle %> 
 <% if @service_opts.is_a? Hash and @service_opts.keys.size > 0 -%>
+  <%- if not @service_opts.has_key?('cert') -%>
+  cert = <%= @cert_real %>
+  <%- end -%>
 
   ; additional service options
   <%- @service_opts.each do |option_name,option_value| -%>


### PR DESCRIPTION
* sometimes you don't want to use stunnel::cert resource
* "cert" options does not make sense in the global context anyway