### PR TITLE
order of filled options in hash is always preserved

### DIFF
--- a/templates/tun.erb
+++ b/templates/tun.erb
@@ -41,7 +41,7 @@ TIMEOUTidle = <%= @timeoutidle %>
 <% if @service_opts.is_a? Hash and @service_opts.keys.size > 0 -%>
 
   ; additional service options
-  <%- @service_opts.each do |option_name,option_value| -%>
+  <%- @service_opts.sort.map do |option_name,option_value| -%>
   <%= option_name %> = <%= option_value %>
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
prevents puppet from unneccessary changes to config file,
thus preventing restarts of the service