### PR TITLE
Added support for an array of global_opts

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -258,6 +258,10 @@ This attribute is optional and defaults to the empty hash {}.
 This attribute can be used to control arbitrary global
 options in the stunnel configuration file.
 
+Support for assigning multiple global opts as an array is also available.
+
+    global_opts => { 'socket' => ['l:TCP_NODELAY=1', 'r:TCP_NODELAY=1'] }
+
 For information on stunnel global options, see [the stunnel documentation](https://www.stunnel.org/static/stunnel.html)
 
 ### install\_service ###

--- a/spec/defines/stunnel_tun_spec.rb
+++ b/spec/defines/stunnel_tun_spec.rb
@@ -63,6 +63,29 @@ describe( 'stunnel::tun', :type => :define ) do
    end
  end
 
+ context "with multipule socket options" do
+   let(:facts) {{ 'osfamily' => 'RedHat' }}
+   let(:title) { 'httpd' }
+   let(:params) {{
+     'accept' => '987',
+     'connect' => 'localhost:789',
+     'cert' => '/etc/pki/tls/cert/my-public.crt',
+     'options' => 'NO_SSLv2',
+     'install_service' => 'true',
+     :output => '/var/log/stunnel/httpd-stunnel.log',
+     :debug => '1',
+     :service_opts => { 'TIMEOUTbusy' => '600' },
+     :global_opts => { 'compression' => 'deflate',
+                       'socket' => ['l:SO_TIMEOUT=1','r:SO_TIMEOUT=2'],
+                     },
+     :timeoutidle => '4000',
+   }}
+   it "should contain multipule socket lines" do
+       should contain_file('/etc/stunnel/conf.d/httpd.conf') \
+           .with_content(/socket\ =\ l:SO_TIMEOUT=1\s+socket\ =\ r:SO_TIMEOUT=2/m)
+   end
+ end
+
  context "with multiple back-end servers" do
    ['rr', 'prio'].each do |failover|
      describe "and failover set to \"#{failover}\"" do

--- a/templates/tun.erb
+++ b/templates/tun.erb
@@ -15,9 +15,15 @@ options = <%= @options %>
 
 <% if @global_opts.is_a? Hash and @global_opts.keys.size > 0 -%>
 
-; additional global options
   <%- @global_opts.sort.map do |option_name,option_value| -%>
+; additional global options
+    <% if option_value.kind_of?(Array) -%>
+      <%- for val in option_value do -%>
+<%= option_name %> = <%= val %>
+      <%- end -%>
+    <% else -%>
 <%= option_name %> = <%= option_value %>
+    <%- end -%>
   <%- end -%>
 <%- end -%>
 


### PR DESCRIPTION
This is my proposed solution to #18 so that you can set multiple socket options.

global_opts => { 'socket' => ['l:TCP_NODELAY=1', 'r:TCP_NODELAY=1'] }

gives the following config section.

socket = l:TCP_NODELAY=1
socket = r:TCP_NODELAY=1

