### PR TITLE
Allow to set multiple options as an array

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -291,7 +291,11 @@ Specify any options that you want to pass to OpenSSL.
 
     options => 'NO_SSLv2',     # SSLv2 is turrible. See: http://osvdb.org/56387
 
-This attribute is optional and defaults to the empty hash {}.
+This attribute is optional and defaults to the empty string ''.
+
+You can specify multiple options by passing an array.
+
+    options => ['NO_SSLv2','NO_SSLv3'],
 
 For more information on this attribute, see [the stunnel documentation](https://www.stunnel.org/static/stunnel.html)
 

--- a/templates/tun.erb
+++ b/templates/tun.erb
@@ -13,11 +13,15 @@ pid = <%= @pid %>
 debug = <%= @debug %>
 
 output = <%= @output_r %>
+<%- if @options.is_a? String and @options != '' -%>
 
-<% if @options != '' -%>
 options = <%= @options %>
-<% end -%>
+<%- elsif @options.is_a? Array -%>
 
+  <%- @options.each do |o| -%>
+options = <%= o %>
+  <%- end -%>
+<%- end -%>
 <% if @global_opts.is_a? Hash and @global_opts.keys.size > 0 -%>
 
   <%- @global_opts.sort.map do |option_name,option_value| -%>


### PR DESCRIPTION
as the [man page] (https://www.stunnel.org/static/stunnel.html) state :
```
options = SSL_OPTIONS

    OpenSSL library options

    The parameter is the OpenSSL option name as described in the SSL_CTX_set_options(3ssl) manual, but without SSL_OP_ prefix. stunnel -options lists the options found to be allowed in the current combination of stunnel and the OpenSSL library used to build it.

    Several options can be used to specify multiple options. An option name can be prepended with a dash ("-") to disable the option.

    For example, for compatibility with the erroneous Eudora SSL implementation, the following option can be used:

        options = DONT_INSERT_EMPTY_FRAGMENTS

    default:

        options = NO_SSLv2
        options = NO_SSLv3
```