### PR TITLE
Multiple options support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -243,7 +243,7 @@ This attribute controls the `debug` service-level option in the stunnel configur
 
 Specify the failover strategy when using multiple back-end servers.
 
-This attribute does not have any effort is you are not specifying multiple backend servers (as an array) as `connect` value.
+This attribute does not have any effect if you are not specifying multiple backend servers (as an array) as `connect` value.
 
 Valid options are `rr` (round-robin) or `prio` (priority/failover, where stunnel will try to connect
 to the first backend, then second, etc.).

--- a/README.markdown
+++ b/README.markdown
@@ -291,7 +291,7 @@ Specify any options that you want to pass to OpenSSL.
 
     options => 'NO_SSLv2',     # SSLv2 is turrible. See: http://osvdb.org/56387
 
-This attribute is optional and defaults to the empty hash {}.
+This attribute is optional and defaults to the empty string ''. Only one option can be specified at present.
 
 For more information on this attribute, see [the stunnel documentation](https://www.stunnel.org/static/stunnel.html)
 

--- a/README.markdown
+++ b/README.markdown
@@ -69,7 +69,7 @@ at `/etc/certs/stunnel-imaps.pem`. Here is the Puppet configuration to do this:
     stunnel::tun { 'imaps':
       accept  => '993',
       connect => 'localhost:143',
-      options => 'NO_SSLv2',
+      options => ['NO_SSLv2'],
       cert    => '/etc/certs/stunnel-imaps.pem',
       client  => false,
     }
@@ -115,7 +115,7 @@ server computer for `db.domain.com`.
     stunnel::tun { 'mysql_stunnel':
       accept  => '3306',               # The stunnel client will listen to this port.
       connect => "db.domain.com:3307", # The stunnel client will connect to this port.
-      options => 'NO_SSLv2',
+      options => ['NO_SSLv2'],
       cert    => '/etc/ssl/certs/mysql_stunnel.pem',
       client  => true,
     }
@@ -128,7 +128,7 @@ This configuration should only be applied to the server computer.
       accept  => '3307', # The stunnel server will listen to this port.
       connect => '3306', # The stunnel server will connect to this port.
                          # Note: I tried 'localhost:3306', but the 'localhost' stopped it from working.
-      options => 'NO_SSLv2',
+      options => ['NO_SSLv2'],
       cert    => '/etc/ssl/certs/mysql_stunnel.pem',
       client  => false,
     }
@@ -289,9 +289,10 @@ will be removed.
 
 Specify any options that you want to pass to OpenSSL.
 
-    options => 'NO_SSLv2',     # SSLv2 is turrible. See: http://osvdb.org/56387
+    options => ['NO_SSLv2'],     # SSLv2 is turrible. See: http://osvdb.org/56387
 
-This attribute is optional and defaults to the empty string ''. Only one option can be specified at present.
+This attribute is optional and defaults to the empty array []. For backwards
+compatability, a single option can be passed as a string.
 
 For more information on this attribute, see [the stunnel documentation](https://www.stunnel.org/static/stunnel.html)
 
@@ -442,7 +443,7 @@ if we use the `stunnel::cert` class.  Here's a full example:
     stunnel::tun { 'imaps':
       accept   => '993',
       connect  => '143',
-      options  => 'NO_SSLv2',
+      options  => ['NO_SSLv2'],
     }
 
     stunnel::cert { 'imaps':

--- a/README.markdown
+++ b/README.markdown
@@ -69,7 +69,7 @@ at `/etc/certs/stunnel-imaps.pem`. Here is the Puppet configuration to do this:
     stunnel::tun { 'imaps':
       accept  => '993',
       connect => 'localhost:143',
-      options => ['NO_SSLv2'],
+      options => ['NO_SSLv2', 'NO_SSLv3'],
       cert    => '/etc/certs/stunnel-imaps.pem',
       client  => false,
     }
@@ -115,7 +115,7 @@ server computer for `db.domain.com`.
     stunnel::tun { 'mysql_stunnel':
       accept  => '3306',               # The stunnel client will listen to this port.
       connect => "db.domain.com:3307", # The stunnel client will connect to this port.
-      options => ['NO_SSLv2'],
+      options => ['NO_SSLv2, 'NO_SSLv3''],
       cert    => '/etc/ssl/certs/mysql_stunnel.pem',
       client  => true,
     }
@@ -128,7 +128,7 @@ This configuration should only be applied to the server computer.
       accept  => '3307', # The stunnel server will listen to this port.
       connect => '3306', # The stunnel server will connect to this port.
                          # Note: I tried 'localhost:3306', but the 'localhost' stopped it from working.
-      options => ['NO_SSLv2'],
+      options => ['NO_SSLv2', 'NO_SSLv3'],
       cert    => '/etc/ssl/certs/mysql_stunnel.pem',
       client  => false,
     }
@@ -289,7 +289,8 @@ will be removed.
 
 Specify any options that you want to pass to OpenSSL.
 
-    options => ['NO_SSLv2'],     # SSLv2 is turrible. See: http://osvdb.org/56387
+    options => ['NO_SSLv2', 'NO_SSLv3'],     # SSLv2 is turrible. See: http://osvdb.org/56387
+                                             # So is SSLv3. See https://www.openssl.org/~bodo/ssl-poodle.pdf
 
 This attribute is optional and defaults to the empty array []. For backwards
 compatability, a single option can be passed as a string.
@@ -443,7 +444,7 @@ if we use the `stunnel::cert` class.  Here's a full example:
     stunnel::tun { 'imaps':
       accept   => '993',
       connect  => '143',
-      options  => ['NO_SSLv2'],
+      options  => ['NO_SSLv2', 'NO_SSLv3'],
     }
 
     stunnel::cert { 'imaps':

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -17,8 +17,9 @@
 #   Whether this tunnel should be setup in client mode.
 #
 # [*options*]
-#   Options to pass to openssl.  To disable SSLv2 on your tunnel, you could pass
-#   "NO_SSLv2" as an option.
+#   Options to pass to openssl.  To disable SSLv2 on your tunnel, you could
+#   pass "NO_SSLv2" as an option. This parameter should be passed an array, but
+#   for backwards compatability a single option can be passed as a string.
 #
 # [*template*]
 #   The ERB template to use when generating the configuration
@@ -55,7 +56,7 @@ define stunnel::tun (
   $cafile = '',
   $cert = 'UNSET',
   $client = false,
-  $options = '',
+  $options = [ ],
   $failover = 'rr',
   $template = 'stunnel/tun.erb',
   $timeoutidle = '43200',
@@ -86,6 +87,14 @@ define stunnel::tun (
   }
   validate_absolute_path( $cert_real )
   validate_bool( str2bool($client) )
+
+  if is_string($options) {
+    $options_r = [ $options ]
+  } elsif is_array($options) {
+    $options_r = $options
+  } else {
+    fail('$options must be an array, or a string containing a single option')
+  }
 
   $pid = "${stunnel::data::pid_dir}/stunnel-${name}.pid"
   $output_r = $output ? {

--- a/spec/defines/stunnel_tun_spec.rb
+++ b/spec/defines/stunnel_tun_spec.rb
@@ -114,4 +114,27 @@ describe( 'stunnel::tun', :type => :define ) do
      end
    end
  end
+
+ context "with an array of options" do
+   let(:facts) {{ 'osfamily' => 'RedHat' }}
+   let(:title) { 'httpd' }
+   let(:params) {{
+     'accept' => '987',
+     'connect' => 'localhost:789',
+     'cert' => '/etc/pki/tls/cert/my-public.crt',
+     'options' => ['NO_SSLv2','NO_SSLv3'],
+     'install_service' => 'true',
+     :output => '/var/log/stunnel/httpd-stunnel.log',
+     :debug => '1',
+     :service_opts => { 'TIMEOUTbusy' => '600' },
+     :global_opts => { 'compression' => 'deflate',
+                       'socket' => ['l:SO_TIMEOUT=1','r:SO_TIMEOUT=2'],
+                     },
+     :timeoutidle => '4000',
+   }}
+   it "should contain multiple options lines" do
+       should contain_file('/etc/stunnel/conf.d/httpd.conf') \
+           .with_content(/options = NO_SSLv2$\s+options = NO_SSLv3$/m)
+   end
+ end
 end

--- a/templates/tun.erb
+++ b/templates/tun.erb
@@ -14,8 +14,8 @@ debug = <%= @debug %>
 
 output = <%= @output_r %>
 
-<% if @options != '' -%>
-options = <%= @options %>
+<% @options_r.each do |option| -%>
+options = <%= option %>
 <% end -%>
 
 <% if @global_opts.is_a? Hash and @global_opts.keys.size > 0 -%>


### PR DESCRIPTION
This PR changes the stunnel::tun options parameter to take an array of options and default to an empty array. At present it only takes a string value and can not support specification of multiple options. For backwards compatibility, you can still specify a single option as a string.

I have also updated the README to show this and to include the NO_SSLv3 option in the examples, as well as the existing NO_SSLv2. The current examples potentially make stunnel less secure than its defaults, as with modern stunnels options defaults to NO_SSLv2 and NO_SSLv3.