### PR TITLE
Anchor regex used to validate failover param

### DIFF
--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -72,7 +72,7 @@ define stunnel::tun (
 
   validate_hash( $global_opts )
   validate_hash( $service_opts )
-  validate_re( $failover, '(rr|prio)', '$failover must be either \'rr\' or \'prio\'')
+  validate_re( $failover, '^(rr|prio)$', '$failover must be either \'rr\' or \'prio\'')
 
   $cafile_real = $cafile ? {
     'UNSET' => '',


### PR DESCRIPTION
Previously, the validation would accept values such as foo_rr or
prio_foo.