### PR TITLE
Add support deploying a systemd service unit config instead of a SysV init script

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -289,6 +289,18 @@ This attribute controls the installation of the init-script for this tunnel. If
 set to true, the init script will be installed. If set to false, the init-script
 will be removed.
 
+### service\_init\_system ###
+
+Specify which init system will be managing the service. If set to 'sysv' then
+a sysvinit style initscript for each tunnel will be placed inside of
+/etc/init.d/stunnel-\<name\>. If set to 'systemd' then a systemd service unit
+config will be placed in /etc/systemd/system/stunnel-\<name\>.service.
+
+    service_init_system => 'sysv',
+    service_init_system => 'systemd',
+
+This attribute is optional and defaults to `sysv`.
+
 ### options ###
 
 Specify any options that you want to pass to OpenSSL.

--- a/manifests/data.pp
+++ b/manifests/data.pp
@@ -16,6 +16,13 @@ class stunnel::data {
       $log_dir = '/var/log/stunnel'
       $setgid = 'root'
       $setuid = 'root'
+
+      if ($::operatingsystem == 'RedHat' and versioncmp($::operatingsystemrelease, '7.0') >= 0) or
+         ($::operatingsystem == 'CentOS' and versioncmp($::operatingsystemrelease, '7.14.04') >= 0) {
+        $service_init_system = 'systemd'
+      } else {
+        $service_init_system = 'sysv'
+      }
     }
     /Debian/: {
       $package = [ 'stunnel4', 'lsb-base' ]
@@ -29,6 +36,13 @@ class stunnel::data {
       $log_dir = '/var/log/stunnel4'
       $setgid = 'root'
       $setuid = 'root'
+
+      if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) or
+         ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8.0') >= 0) {
+        $service_init_system = 'systemd'
+      } else {
+        $service_init_system = 'sysv'
+      }
     }
 
     default: {

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -54,6 +54,15 @@
 #   whether to set up or remove this tunnel. Valid values are 'absent' and
 #   'present'. Defaults to 'present'.
 #
+# [*install_service*]
+#   Whether or not to install an init script for this tunnel (boolean).
+#   Defaults to true
+#
+# [*service_init_system*]
+#   Which init system will be managing this service. Valid values are 'sysv'
+#   and 'systemd'.
+#   Defaults to 'sysv'
+#
 define stunnel::tun (
   $accept,
   $connect,

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -138,7 +138,8 @@ define stunnel::tun (
   } else {
     $initscript_ensure = 'absent'
   }
-  file { "/etc/init.d/stunnel-${name}":
+  $initscript_file = "/etc/init.d/stunnel-${name}"
+  file { $initscript_file:
     ensure  => $initscript_ensure,
     owner   => 'root',
     group   => 'root',
@@ -152,13 +153,13 @@ define stunnel::tun (
       # When removing, the init file should be removed after the service is
       # stopped
       $service_require = undef
-      $service_before = File["/etc/init.d/stunnel-${name}"]
+      $service_before = File[$initscript_file]
     } else {
       $service_ensure_real = $service_ensure
       $service_enable = true
       # When installing, the init file should be created before the service is
       # started
-      $service_require = File["/etc/init.d/stunnel-${name}"]
+      $service_require = File[$initscript_file]
       $service_before = undef
     }
     service { "stunnel-${name}":

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -67,6 +67,7 @@ define stunnel::tun (
   $debug = '5',
   $install_service = true,
   $service_ensure = 'running',
+  $service_init_system = 'sysv',
   $output = 'UNSET',
   $global_opts = { },
   $service_opts = { },
@@ -138,13 +139,24 @@ define stunnel::tun (
   } else {
     $initscript_ensure = 'absent'
   }
-  $initscript_file = "/etc/init.d/stunnel-${name}"
-  file { $initscript_file:
-    ensure  => $initscript_ensure,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0550',
-    content => template('stunnel/stunnel.init.erb'),
+  if $service_init_system == 'sysv' {
+    $initscript_file = "/etc/init.d/stunnel-${name}"
+    file { $initscript_file:
+      ensure  => $initscript_ensure,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0550',
+      content => template('stunnel/stunnel.init.erb'),
+    }
+  } elsif $service_init_system == 'systemd' {
+    $initscript_file = "/etc/systemd/system/stunnel-${name}.service"
+    file { $initscript_file:
+      ensure  => $initscript_ensure,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      content => template('stunnel/stunnel.init.systemd.erb'),
+    }
   }
   if $install_service or $ensure == 'absent' {
     if $ensure == 'absent' {

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -141,7 +141,7 @@ define stunnel::tun (
     owner   => 'root',
     group   => 'root',
     mode    => '0444',
-    content => template("${template}"),
+    content => template($template),
   }
 
   # setup our init script / service
@@ -163,9 +163,9 @@ define stunnel::tun (
     $initscript_file = "/etc/systemd/system/stunnel-${name}.service"
     file { $initscript_file:
       ensure  => $initscript_ensure,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
       content => template('stunnel/stunnel.init.systemd.erb'),
     }
   }

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -85,6 +85,8 @@ define stunnel::tun (
   require stunnel
   include stunnel::data
 
+  validate_re( $service_init_system, '^(sysv|systemd)$',
+    '$service_init_system must be either \'sysv\' or \'systemd\'')
   validate_hash( $global_opts )
   validate_hash( $service_opts )
   validate_re( $failover, '^(rr|prio)$', '$failover must be either \'rr\' or \'prio\'')

--- a/spec/defines/stunnel_tun_spec.rb
+++ b/spec/defines/stunnel_tun_spec.rb
@@ -159,5 +159,28 @@ describe( 'stunnel::tun', :type => :define ) do
      it { should contain_service('stunnel-mytunnel').that_comes_before('File[/etc/init.d/stunnel-mytunnel]') }
  end
 
+ context 'with service_init_system = systemd' do
+   let(:facts) {{ 'osfamily' => 'RedHat' }}
+   let(:title) { 'mytunnel' }
+   let(:params) {{
+     :accept => '1234',
+     :connect => '2345',
+     :install_service => 'true',
+     :service_init_system => 'systemd',
+   }}
+
+   it 'should contain a systemd service unit config' do
+     should contain_file('/etc/systemd/system/stunnel-mytunnel.service').with_ensure('present')
+   end
+
+   it 'should contain a service which requires the service unit config' do
+     should contain_service('stunnel-mytunnel').with({
+       'enable' => true,
+       'require' => 'File[/etc/systemd/system/stunnel-mytunnel.service]',
+       'subscribe' => 'File[/etc/stunnel/conf.d/mytunnel.conf]',
+     })
+   end
+ end
+
  context ""
 end

--- a/spec/defines/stunnel_tun_spec.rb
+++ b/spec/defines/stunnel_tun_spec.rb
@@ -22,6 +22,18 @@ describe( 'stunnel::tun', :type => :define ) do
        should contain_file('/etc/stunnel/conf.d/my-tunnel.conf').with_content(l)
      end
    end
+
+   it 'should contain a sysv init script' do
+     should contain_file('/etc/init.d/stunnel-my-tunnel').with_ensure('present')
+   end
+
+   it 'should contain a service which requires the init script' do
+     should contain_service('stunnel-my-tunnel').with({
+       'enable' => true,
+       'require' => 'File[/etc/init.d/stunnel-my-tunnel]',
+       'subscribe' => 'File[/etc/stunnel/conf.d/my-tunnel.conf]',
+     })
+   end
  end
 
  context "with non-defaults" do

--- a/spec/defines/stunnel_tun_spec.rb
+++ b/spec/defines/stunnel_tun_spec.rb
@@ -53,12 +53,6 @@ describe( 'stunnel::tun', :type => :define ) do
      :timeoutidle => '4000',
    }}
    it do
-     should contain_service('stunnel-httpd').with({
-       'enable' => true,
-       'require' => 'File[/etc/init.d/stunnel-httpd]',
-       'subscribe' => 'File[/etc/stunnel/conf.d/httpd.conf]',
-     })
-
      lines = [
        /accept=987/,
        /connect=localhost:789/,

--- a/spec/defines/stunnel_tun_spec.rb
+++ b/spec/defines/stunnel_tun_spec.rb
@@ -5,8 +5,8 @@ describe( 'stunnel::tun', :type => :define ) do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'my-tunnel' }
    let(:params) {{
-     'accept' => '1234',
-     'connect' => '2345',
+     :accept => '1234',
+     :connect => '2345',
    }}
    it do
      lines = [
@@ -29,9 +29,9 @@ describe( 'stunnel::tun', :type => :define ) do
 
    it 'should contain a service which requires the init script' do
      should contain_service('stunnel-my-tunnel').with({
-       'enable' => true,
-       'require' => 'File[/etc/init.d/stunnel-my-tunnel]',
-       'subscribe' => 'File[/etc/stunnel/conf.d/my-tunnel.conf]',
+       :enable => true,
+       :require => 'File[/etc/init.d/stunnel-my-tunnel]',
+       :subscribe => 'File[/etc/stunnel/conf.d/my-tunnel.conf]',
      })
    end
  end
@@ -40,12 +40,12 @@ describe( 'stunnel::tun', :type => :define ) do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'httpd' }
    let(:params) {{
-     'accept' => '987',
-     'connect' => 'localhost:789',
-     'cert' => '/etc/pki/tls/cert/my-public.crt',
+     :accept => '987',
+     :connect => 'localhost:789',
+     :cert => '/etc/pki/tls/cert/my-public.crt',
      :cafile => '/etc/pki/tls/certs/ca-bundle.crt',
-     'options' => 'NO_SSLv2',
-     'install_service' => 'true',
+     :options => 'NO_SSLv2',
+     :install_service => 'true',
      :output => '/var/log/stunnel/httpd-stunnel.log',
      :debug => '1',
      :service_opts => { 'TIMEOUTbusy' => '600' },
@@ -76,11 +76,11 @@ describe( 'stunnel::tun', :type => :define ) do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'httpd' }
    let(:params) {{
-     'accept' => '987',
-     'connect' => 'localhost:789',
-     'cert' => '/etc/pki/tls/cert/my-public.crt',
-     'options' => 'NO_SSLv2',
-     'install_service' => 'true',
+     :accept => '987',
+     :connect => 'localhost:789',
+     :cert => '/etc/pki/tls/cert/my-public.crt',
+     :options => 'NO_SSLv2',
+     :install_service => 'true',
      :output => '/var/log/stunnel/httpd-stunnel.log',
      :debug => '1',
      :service_opts => { 'TIMEOUTbusy' => '600' },
@@ -125,11 +125,11 @@ describe( 'stunnel::tun', :type => :define ) do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'httpd' }
    let(:params) {{
-     'accept' => '987',
-     'connect' => 'localhost:789',
-     'cert' => '/etc/pki/tls/cert/my-public.crt',
-     'options' => ['NO_SSLv2','NO_SSLv3'],
-     'install_service' => 'true',
+     :accept => '987',
+     :connect => 'localhost:789',
+     :cert => '/etc/pki/tls/cert/my-public.crt',
+     :options => ['NO_SSLv2','NO_SSLv3'],
+     :install_service => 'true',
      :output => '/var/log/stunnel/httpd-stunnel.log',
      :debug => '1',
      :service_opts => { 'TIMEOUTbusy' => '600' },
@@ -181,9 +181,9 @@ describe( 'stunnel::tun', :type => :define ) do
 
    it 'should contain a service which requires the service unit config' do
      should contain_service('stunnel-mytunnel').with({
-       'enable' => true,
-       'require' => 'File[/etc/systemd/system/stunnel-mytunnel.service]',
-       'subscribe' => 'File[/etc/stunnel/conf.d/mytunnel.conf]',
+       :enable => true,
+       :require => 'File[/etc/systemd/system/stunnel-mytunnel.service]',
+       :subscribe => 'File[/etc/stunnel/conf.d/mytunnel.conf]',
      })
    end
  end

--- a/spec/defines/stunnel_tun_spec.rb
+++ b/spec/defines/stunnel_tun_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe( 'stunnel::tun', :type => :define ) do
- context "with a basic tunnel" do
+ context 'with a basic tunnel' do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'my-tunnel' }
    let(:params) {{
@@ -36,7 +36,7 @@ describe( 'stunnel::tun', :type => :define ) do
    end
  end
 
- context "with non-defaults" do
+ context 'with non-defaults' do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'httpd' }
    let(:params) {{
@@ -72,7 +72,7 @@ describe( 'stunnel::tun', :type => :define ) do
    end
  end
 
- context "with multipule socket options" do
+ context 'with multipule socket options' do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'httpd' }
    let(:params) {{
@@ -89,13 +89,13 @@ describe( 'stunnel::tun', :type => :define ) do
                      },
      :timeoutidle => '4000',
    }}
-   it "should contain multipule socket lines" do
+   it 'should contain multipule socket lines' do
        should contain_file('/etc/stunnel/conf.d/httpd.conf') \
            .with_content(/socket\ =\ l:SO_TIMEOUT=1\s+socket\ =\ r:SO_TIMEOUT=2/m)
    end
  end
 
- context "with multiple back-end servers" do
+ context 'with multiple back-end servers' do
    ['rr', 'prio'].each do |failover|
      describe "and failover set to \"#{failover}\"" do
        let(:facts) {{ 'osfamily' => 'RedHat' }}
@@ -121,7 +121,7 @@ describe( 'stunnel::tun', :type => :define ) do
    end
  end
 
- context "with an array of options" do
+ context 'with an array of options' do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'httpd' }
    let(:params) {{
@@ -138,13 +138,13 @@ describe( 'stunnel::tun', :type => :define ) do
                      },
      :timeoutidle => '4000',
    }}
-   it "should contain multiple options lines" do
+   it 'should contain multiple options lines' do
        should contain_file('/etc/stunnel/conf.d/httpd.conf') \
            .with_content(/options = NO_SSLv2$\s+options = NO_SSLv3$/m)
    end
  end
 
- context "with ensure = absent" do
+ context 'with ensure = absent' do
    let(:facts) {{ 'osfamily' => 'RedHat' }}
    let(:title) { 'mytunnel' }
    let(:params) {{
@@ -188,5 +188,5 @@ describe( 'stunnel::tun', :type => :define ) do
    end
  end
 
- context ""
+ context ''
 end

--- a/templates/stunnel.init.systemd.erb
+++ b/templates/stunnel.init.systemd.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=Stunnel (<%= @name %>)
+Documentation=man:stunnel(8)
+After=syslog.target network.target
+
+[Service]
+Type=forking
+GuessMainPID=no
+PIDFile=<%= @pid %>
+ExecStart=<%= @svc_bin %> <%= @config_file %>
+KillMode=process
+TimeoutStopSec=2
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds support for deploying a systemd service unit config instead of a SysV init script. It also includes a small amount of cleanup within the spec tests.

The systemd config is deployed when the new stunnel::tun parameter `service_init_system` is set to 'systemd'. This parameter defaults to 'sysv', preserving current behaviour.

All tests pass with puppet 3.7.4. The Gemfile specifies a default puppet version of 2.7, for which all tests fail for me (even before I made any changes).