### PR TITLE
Move cert and CAfile into [service] options (fixes #39).

### DIFF
--- a/templates/tun.erb
+++ b/templates/tun.erb
@@ -1,12 +1,4 @@
 # This file managed by Puppet
-<% if @cert_real != '' -%>
-cert = <%= @cert_real %>
-<% end -%>
-<% if @cafile_real != '' -%>
-CAfile = <%= @cafile_real %>
-<% else -%>
-# CAfile = /path/to/cafile.crt
-<% end -%>
 
 setuid = root
 setgid = root
@@ -35,6 +27,14 @@ options = <%= option %>
 <%- end -%>
 
 [<%= @name %>]
+<% if @cert_real != '' -%>
+cert = <%= @cert_real %>
+<% end -%>
+<% if @cafile_real != '' -%>
+CAfile = <%= @cafile_real %>
+<% else -%>
+# CAfile = /path/to/cafile.crt
+<% end -%>
 <% if @accept -%>
   accept=<%= @accept %>
 <% end -%>


### PR DESCRIPTION
stunnel4(8) explicitly details that these options are service-level options and not global options. This commit fixes this