### PR TITLE
Make log directory writeable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,6 @@ class stunnel::config {
   $stunnel_dirs = [
     $stunnel::data::config_dir,
     $stunnel::data::conf_d_dir,
-    $stunnel::data::log_dir,
   ]
 
   file { $stunnel_dirs:
@@ -15,5 +14,12 @@ class stunnel::config {
     owner  => 'root',
     group  => 'root',
     mode   => '0555',
+  }
+
+  file { $stunnel::data::log_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
   }
 }


### PR DESCRIPTION
The log directory being read-only requires stunnel to have
CAP_DAC_OVERRIDE which in times of systemd is not necessarily the case
even when running as root. Typical errors are:

stunnel[1234]: Cannot open log file: /var/log/stunnel/service.log

The audit framework reports in such a case:

type=AVC ... avc: denied { dac_override } for pid=1234 comm="stunnel"
capability=1 ... tclass=capability

Making the directory writeable for owner root solves the problem.